### PR TITLE
Creates two new panels: Transitions and Durations

### DIFF
--- a/src/components/panel-list.vue
+++ b/src/components/panel-list.vue
@@ -68,7 +68,7 @@
 		},
 		{
 			name: 'Set Transition',
-			description: 'Set the current transition (based on the Quick Transition List)',
+			description: 'Set the current transition',
 			icon: 'view_list', //TODO: figure this out (needs a different icon)
 			type: 'Transitions'
 		},

--- a/src/components/panel-list.vue
+++ b/src/components/panel-list.vue
@@ -61,16 +61,22 @@
 			type: 'Sources'
 		},
 		{
-			name: 'Stream Status',
-			description: 'Manage stream & recording status',
-			icon: 'movie',
-			type: 'Stream'
-		},
-		{
 			name: 'Set Transition',
 			description: 'Set the current transition',
 			icon: 'view_list', // TODO: figure this out (needs a different icon)
 			type: 'Transitions'
+		},
+		{
+			name: 'Set Duration',
+			description: 'Set the current duration',
+			icon: 'view_list', // TODO: figure this out (needs a different icon)
+			type: 'Durations'
+		},
+		{
+			name: 'Stream Status',
+			description: 'Manage stream & recording status',
+			icon: 'movie',
+			type: 'Stream'
 		},
 		{
 			name: 'Frame',

--- a/src/components/panel-list.vue
+++ b/src/components/panel-list.vue
@@ -63,13 +63,13 @@
 		{
 			name: 'Set Transition',
 			description: 'Set the current transition',
-			icon: 'view_list', // TODO: figure this out (needs a different icon)
+			icon: 'timelapse',
 			type: 'Transitions'
 		},
 		{
 			name: 'Set Duration',
 			description: 'Set the current duration',
-			icon: 'view_list', // TODO: figure this out (needs a different icon)
+			icon: 'timelapse', 
 			type: 'Durations'
 		},
 		{

--- a/src/components/panel-list.vue
+++ b/src/components/panel-list.vue
@@ -67,6 +67,12 @@
 			type: 'Stream'
 		},
 		{
+			name: 'Set Transition',
+			description: 'Set the current transition (based on the Quick Transition List)',
+			icon: 'view_list', //TODO: figure this out (needs a different icon)
+			type: 'Transitions'
+		},
+		{
 			name: 'Frame',
 			description: 'Embed any webpage',
 			icon: 'web_asset',

--- a/src/components/panel-list.vue
+++ b/src/components/panel-list.vue
@@ -63,13 +63,13 @@
 		{
 			name: 'Set Transition',
 			description: 'Set the current transition',
-			icon: 'timelapse',
+			icon: 'blur_linear',
 			type: 'Transitions'
 		},
 		{
 			name: 'Set Duration',
 			description: 'Set the current duration',
-			icon: 'timelapse', 
+			icon: 'timelapse',
 			type: 'Durations'
 		},
 		{

--- a/src/components/panel-list.vue
+++ b/src/components/panel-list.vue
@@ -69,7 +69,7 @@
 		{
 			name: 'Set Transition',
 			description: 'Set the current transition',
-			icon: 'view_list', //TODO: figure this out (needs a different icon)
+			icon: 'view_list', // TODO: figure this out (needs a different icon)
 			type: 'Transitions'
 		},
 		{

--- a/src/components/panels/durations.vue
+++ b/src/components/panels/durations.vue
@@ -6,9 +6,9 @@
 			<button
 				class="duration"
 				v-for="duration in allDurations"
-				:class="[duration.duration === currentDuration ? 'is-active' : 'is-inactive']"
-				:key="duration.duration"
-				@click="changeDuration(duration.duration)">{{ duration.duration }}ms</button>
+				:class="[duration === currentDuration ? 'is-active' : 'is-inactive']"
+				:key="duration"
+				@click="changeDuration(duration)">{{ duration }}ms</button>
 		</div>
 	</panel-wrapper>
 </template>

--- a/src/components/panels/durations.vue
+++ b/src/components/panels/durations.vue
@@ -1,0 +1,48 @@
+<template>
+	<panel-wrapper :content-class="['panel-durations']">
+		<template slot="name">Durations</template>
+		<h3 class="current-duration">{{ currentDuration }}ms</h3>
+		<div class="durations" v-if="allDurations">
+			<button
+				class="duration"
+				v-for="duration in allDurations"
+				:class="[duration.duration === currentDuration ? 'is-active' : 'is-inactive']"
+				:key="duration.duration"
+				@click="changeDuration(duration.duration)">{{ duration.duration }}ms</button>
+		</div>
+	</panel-wrapper>
+</template>
+
+<script>
+import {mapState, mapActions} from 'vuex'
+import panelMixin from '../mixins/panel'
+export default {
+
+	mixins: [panelMixin],
+
+	data() {
+		const data = {
+			staticDurations: [{duration: 100}, {duration: 300}, {duration: 600}, {duration: 1000}, {duration: 1500}]
+			// Static durations logrithmic in nature
+		}
+		return data
+	},
+
+	computed: {
+		...mapState('obs', {
+			currentDuration: state => state.durations.current,
+			allDurations: state => state.durations.list
+		})
+	},
+
+	methods: {
+		async changeDuration(ms) {
+			await this.setDuration({ms})
+		},
+		...mapActions('obs', {
+			setDuration: 'duration/current'
+		})
+	}
+}
+
+</script>

--- a/src/components/panels/durations.vue
+++ b/src/components/panels/durations.vue
@@ -16,8 +16,8 @@
 <script>
 import {mapState, mapActions} from 'vuex'
 import panelMixin from '../mixins/panel'
-export default {
 
+export default {
 	mixins: [panelMixin],
 
 	data() {

--- a/src/components/panels/durations.vue
+++ b/src/components/panels/durations.vue
@@ -40,7 +40,7 @@ export default {
 			await this.setDuration({ms})
 		},
 		...mapActions('obs', {
-			setDuration: 'duration/current'
+			setDuration: 'durations/current'
 		})
 	}
 }

--- a/src/components/panels/index.js
+++ b/src/components/panels/index.js
@@ -7,6 +7,7 @@ import Invalid from './invalid'
 import Scenes from './scenes'
 import Sources from './sources'
 import Stream from './stream'
+import Transitions from './transitions'
 
 const components = {
 	Grid,
@@ -14,6 +15,7 @@ const components = {
 	Invalid,
 	Scenes,
 	Sources,
+	Transitions,
 	Stream
 }
 

--- a/src/components/panels/index.js
+++ b/src/components/panels/index.js
@@ -8,6 +8,7 @@ import Scenes from './scenes'
 import Sources from './sources'
 import Stream from './stream'
 import Transitions from './transitions'
+import Durations from './durations'
 
 const components = {
 	Grid,
@@ -16,6 +17,7 @@ const components = {
 	Scenes,
 	Sources,
 	Transitions,
+	Durations,
 	Stream
 }
 

--- a/src/components/panels/transitions.vue
+++ b/src/components/panels/transitions.vue
@@ -1,0 +1,69 @@
+<template>
+	<panel-wrapper :content-class="['panel-transitions']">
+		<template slot="name">Transitions</template>
+		<div class="transitions" v-if="allTransitions">
+			<button
+			  class="transition"
+				v-for="transition in allTransitions"
+				:key="transition.name"
+				:class="[transition.name === currentTransition ? 'is-active' : 'is-inactive']"
+				@click="switchTransitions(transition.name)"
+				v-text="transition.name" />
+			<hr/>
+			<button
+				class="duration"
+				v-for="duration in staticDurations"
+				:class="[duration.duration === currentDuration ? 'is-active' : 'is-inactive']"
+				:key="duration.duration"
+				@click="changeDuration(duration.duration)">{{ duration.duration }}ms</button>
+	  </div>
+		<div v-else>
+			Quick Transition list is empty! Should minimally have 'Cut' and 'Fade' ... Something is wrong :(
+		</div>
+
+	</panel-wrapper>
+
+</template>
+
+<script> //TODO: determine active transition and add is-active is-inactive logic (also something like that for duration)
+import {mapState, mapActions} from 'vuex'
+
+import panelMixin from '../mixins/panel'
+
+	export default {
+
+		data() {
+			const data = {
+				staticDurations: [ {duration: 100}, {duration: 300}, {duration: 600}, {duration: 1000}, {duration: 1500} ]
+				// static durations logrithmic in nature
+			}
+			return data;
+		},
+
+		mixins: [panelMixin],
+
+		computed: {
+			...mapState('obs', {
+				currentTransition: state => state.transitions.current,
+				currentDuration: state => state.transitions.duration,
+				allTransitions: state => state.transitions.list,
+			})
+		},
+
+		methods: {
+			setDurationX(duration) {
+				alert('TODO: duration to '+duration+'ms');
+			},
+			async switchTransitions(name) {
+				await this.setTransition({name})
+			},
+			async changeDuration(ms) {
+				await this.setDuration({ms})
+			},
+			...mapActions('obs', {
+				setTransition: 'transitions/current',
+				setDuration: 'transitions/duration'
+			})
+		}
+	}
+</script>

--- a/src/components/panels/transitions.vue
+++ b/src/components/panels/transitions.vue
@@ -9,43 +9,23 @@
 				:class="[transition.name === currentTransition ? 'is-active' : 'is-inactive']"
 				@click="switchTransitions(transition.name)"
 				v-text="transition.name"></button>
-			<hr></hr>
-			<button
-				class="duration"
-				v-for="duration in staticDurations"
-				:class="[duration.duration === currentDuration ? 'is-active' : 'is-inactive']"
-				:key="duration.duration"
-				@click="changeDuration(duration.duration)">{{ duration.duration }}ms</button>
 		</div>
 		<div v-else>
 			Transition list is empty! Should minimally have 'Cut' and 'Fade' ... Something is wrong :(
 		</div>
-
 	</panel-wrapper>
-
 </template>
 
 <script>
 import {mapState, mapActions} from 'vuex'
-
 import panelMixin from '../mixins/panel'
-
 export default {
 
 	mixins: [panelMixin],
 
-	data() {
-		const data = {
-			staticDurations: [{duration: 100}, {duration: 300}, {duration: 600}, {duration: 1000}, {duration: 1500}]
-			// Static durations logrithmic in nature
-		}
-		return data
-	},
-
 	computed: {
 		...mapState('obs', {
 			currentTransition: state => state.transitions.current,
-			currentDuration: state => state.transitions.duration,
 			allTransitions: state => state.transitions.list
 		})
 	},
@@ -54,12 +34,8 @@ export default {
 		async switchTransitions(name) {
 			await this.setTransition({name})
 		},
-		async changeDuration(ms) {
-			await this.setDuration({ms})
-		},
 		...mapActions('obs', {
 			setTransition: 'transitions/current',
-			setDuration: 'transitions/duration'
 		})
 	}
 }

--- a/src/components/panels/transitions.vue
+++ b/src/components/panels/transitions.vue
@@ -3,20 +3,20 @@
 		<template slot="name">Transitions</template>
 		<div class="transitions" v-if="allTransitions">
 			<button
-			  class="transition"
+				class="transition"
 				v-for="transition in allTransitions"
 				:key="transition.name"
 				:class="[transition.name === currentTransition ? 'is-active' : 'is-inactive']"
 				@click="switchTransitions(transition.name)"
-				v-text="transition.name" />
-			<hr/>
+				v-text="transition.name"></button>
+			<hr></hr>
 			<button
 				class="duration"
 				v-for="duration in staticDurations"
 				:class="[duration.duration === currentDuration ? 'is-active' : 'is-inactive']"
 				:key="duration.duration"
 				@click="changeDuration(duration.duration)">{{ duration.duration }}ms</button>
-	  </div>
+		</div>
 		<div v-else>
 			Transition list is empty! Should minimally have 'Cut' and 'Fade' ... Something is wrong :(
 		</div>
@@ -25,42 +25,43 @@
 
 </template>
 
-<script> 
+<script>
 import {mapState, mapActions} from 'vuex'
 
 import panelMixin from '../mixins/panel'
 
-	export default {
+export default {
 
-		data() {
-			const data = {
-				staticDurations: [ {duration: 100}, {duration: 300}, {duration: 600}, {duration: 1000}, {duration: 1500} ]
-				// static durations logrithmic in nature
-			}
-			return data;
-		},
+	mixins: [panelMixin],
 
-		mixins: [panelMixin],
-
-		computed: {
-			...mapState('obs', {
-				currentTransition: state => state.transitions.current,
-				currentDuration: state => state.transitions.duration,
-				allTransitions: state => state.transitions.list,
-			})
-		},
-
-		methods: {
-			async switchTransitions(name) {
-				await this.setTransition({name})
-			},
-			async changeDuration(ms) {
-				await this.setDuration({ms})
-			},
-			...mapActions('obs', {
-				setTransition: 'transitions/current',
-				setDuration: 'transitions/duration'
-			})
+	data() {
+		const data = {
+			staticDurations: [{duration: 100}, {duration: 300}, {duration: 600}, {duration: 1000}, {duration: 1500}]
+			// Static durations logrithmic in nature
 		}
+		return data
+	},
+
+	computed: {
+		...mapState('obs', {
+			currentTransition: state => state.transitions.current,
+			currentDuration: state => state.transitions.duration,
+			allTransitions: state => state.transitions.list
+		})
+	},
+
+	methods: {
+		async switchTransitions(name) {
+			await this.setTransition({name})
+		},
+		async changeDuration(ms) {
+			await this.setDuration({ms})
+		},
+		...mapActions('obs', {
+			setTransition: 'transitions/current',
+			setDuration: 'transitions/duration'
+		})
 	}
+}
+
 </script>

--- a/src/components/panels/transitions.vue
+++ b/src/components/panels/transitions.vue
@@ -18,14 +18,14 @@
 				@click="changeDuration(duration.duration)">{{ duration.duration }}ms</button>
 	  </div>
 		<div v-else>
-			Quick Transition list is empty! Should minimally have 'Cut' and 'Fade' ... Something is wrong :(
+			Transition list is empty! Should minimally have 'Cut' and 'Fade' ... Something is wrong :(
 		</div>
 
 	</panel-wrapper>
 
 </template>
 
-<script> //TODO: determine active transition and add is-active is-inactive logic (also something like that for duration)
+<script> 
 import {mapState, mapActions} from 'vuex'
 
 import panelMixin from '../mixins/panel'
@@ -51,9 +51,6 @@ import panelMixin from '../mixins/panel'
 		},
 
 		methods: {
-			setDurationX(duration) {
-				alert('TODO: duration to '+duration+'ms');
-			},
 			async switchTransitions(name) {
 				await this.setTransition({name})
 			},

--- a/src/components/panels/transitions.vue
+++ b/src/components/panels/transitions.vue
@@ -19,6 +19,7 @@
 <script>
 import {mapState, mapActions} from 'vuex'
 import panelMixin from '../mixins/panel'
+
 export default {
 
 	mixins: [panelMixin],
@@ -35,7 +36,7 @@ export default {
 			await this.setTransition({name})
 		},
 		...mapActions('obs', {
-			setTransition: 'transitions/current',
+			setTransition: 'transitions/current'
 		})
 	}
 }

--- a/src/store/plugins/obs/module/durations.js
+++ b/src/store/plugins/obs/module/durations.js
@@ -1,0 +1,35 @@
+export default {
+	state: {
+		// Static/initial durations logrithmic in nature
+		list: [{duration: 100}, {duration: 300}, {duration: 600}, {duration: 1000}, {duration: 1500}],
+		current: null
+	},
+	actions: {
+		'connection/closed'({commit}) {
+			commit('transitions/reset')
+		},
+		'connection/ready'({dispatch}) {
+			return dispatch('duration/reload')
+		},
+		async 'duration/reload'({commit, getters: {client}}) {
+			const {'transition-duration': duration} = await client.send({'request-type': 'GetTransitionDuration'})
+
+			commit('duration/current', {duration})
+		},
+		'duration/current'({getters: {client}}, {ms}) {
+			return client.send({'request-type': 'SetTransitionDuration', 'duration': ms})
+		},
+		'event/TransitionDurationChanged'({commit}, data) {
+			commit('duration/durationChanged', data)
+		}
+	},
+	mutations: {
+		'duration/reset'(state) {
+			state.list = [{duration: 100}, {duration: 300}, {duration: 600}, {duration: 1000}, {duration: 1500}]
+			state.current = null
+		},
+		'duration/durationChanged'(state, {'new-duration': newDuration}) {
+			state.current = newDuration
+		}
+	}
+}

--- a/src/store/plugins/obs/module/durations.js
+++ b/src/store/plugins/obs/module/durations.js
@@ -9,26 +9,29 @@ export default {
 			commit('transitions/reset')
 		},
 		'connection/ready'({dispatch}) {
-			return dispatch('duration/reload')
+			return dispatch('durations/reload')
 		},
-		async 'duration/reload'({commit, getters: {client}}) {
+		async 'durations/reload'({commit, getters: {client}}) {
 			const {'transition-duration': duration} = await client.send({'request-type': 'GetTransitionDuration'})
 
-			commit('duration/current', {duration})
+			commit('durations/current', {duration})
 		},
-		'duration/current'({getters: {client}}, {ms}) {
+		'durations/current'({getters: {client}}, {ms}) {
 			return client.send({'request-type': 'SetTransitionDuration', 'duration': ms})
 		},
 		'event/TransitionDurationChanged'({commit}, data) {
-			commit('duration/durationChanged', data)
+			commit('durations/durationChanged', data)
 		}
 	},
 	mutations: {
-		'duration/reset'(state) {
+		'durations/current'(state, {duration}) {
+			state.current = duration
+		},
+		'durations/reset'(state) {
 			state.list = [{duration: 100}, {duration: 300}, {duration: 600}, {duration: 1000}, {duration: 1500}]
 			state.current = null
 		},
-		'duration/durationChanged'(state, {'new-duration': newDuration}) {
+		'durations/durationChanged'(state, {'new-duration': newDuration}) {
 			state.current = newDuration
 		}
 	}

--- a/src/store/plugins/obs/module/durations.js
+++ b/src/store/plugins/obs/module/durations.js
@@ -1,7 +1,7 @@
 export default {
 	state: {
 		// Static/initial durations logrithmic in nature
-		list: [ 100, 300, 600, 1000, 1500],
+		list: [100, 300, 600, 1000, 1500],
 		current: null
 	},
 	actions: {
@@ -28,7 +28,7 @@ export default {
 			state.current = duration
 		},
 		'durations/reset'(state) {
-			state.list = [ 100, 300, 600, 1000, 1500]
+			state.list = [100, 300, 600, 1000, 1500]
 			state.current = null
 		},
 		'durations/durationChanged'(state, {'new-duration': newDuration}) {

--- a/src/store/plugins/obs/module/durations.js
+++ b/src/store/plugins/obs/module/durations.js
@@ -1,7 +1,7 @@
 export default {
 	state: {
 		// Static/initial durations logrithmic in nature
-		list: [{duration: 100}, {duration: 300}, {duration: 600}, {duration: 1000}, {duration: 1500}],
+		list: [ 100, 300, 600, 1000, 1500],
 		current: null
 	},
 	actions: {
@@ -28,7 +28,7 @@ export default {
 			state.current = duration
 		},
 		'durations/reset'(state) {
-			state.list = [{duration: 100}, {duration: 300}, {duration: 600}, {duration: 1000}, {duration: 1500}]
+			state.list = [ 100, 300, 600, 1000, 1500]
 			state.current = null
 		},
 		'durations/durationChanged'(state, {'new-duration': newDuration}) {

--- a/src/store/plugins/obs/module/transitions.js
+++ b/src/store/plugins/obs/module/transitions.js
@@ -22,8 +22,8 @@ export default {
 		'transitions/current'({getters: {client}}, {name}) {
 			return client.send({'request-type': 'SetCurrentTransition', 'transition-name': name})
 		},
-		'transitions/duration'({getters: {client}}, {ms}) {
-			return client.send({'request-type': 'SetTransitionDuration', 'duration': ms})
+		'transitions/duration'({getters: {client}}, duration) {
+			return client.send({'request-type': 'SetTransitionDuration', duration})
 		},
 		'event/SwitchTransition'({dispatch}) {
 			return dispatch('transitions/reload')
@@ -35,11 +35,9 @@ export default {
 			console.log('TransitionBegin', data) // TODO: figure out proper conditional logging
 		},
 		'event/TransitionDurationChanged'({commit}, data) {
-			//console.log('TransitionDurationChanged', data) // TODO: figure out proper conditional logging
-			commit('transitions/durationChanged',data)
+			commit('transitions/durationChanged', data)
 		}
 	},
-	// getters here?
 	mutations: {
 		'transitions/current'(state, {'current-transition': name}) {
 			state.current = name

--- a/src/store/plugins/obs/module/transitions.js
+++ b/src/store/plugins/obs/module/transitions.js
@@ -11,7 +11,7 @@ export default {
 			return dispatch('transitions/reload')
 		},
 		async 'transitions/reload'({commit, getters: {client}}) {
-			const {'current-transition': current, 'transitions': transitions} = await client.send({'request-type': 'GetTransitionList'})
+			const {'current-transition': current, transitions} = await client.send({'request-type': 'GetTransitionList'})
 
 			commit('transitions/list', {transitions})
 			commit('transitions/current', {

--- a/src/store/plugins/obs/module/transitions.js
+++ b/src/store/plugins/obs/module/transitions.js
@@ -21,8 +21,8 @@ export default {
 		'transitions/current'({getters: {client}}, {name}) {
 			return client.send({'request-type': 'SetCurrentTransition', 'transition-name': name})
 		},
-		'event/SwitchTransition'({dispatch}) {
-			return dispatch('transitions/reload')
+		'event/SwitchTransition'({commit}, data) {
+			commit('transitions/newcurrent',  data)
 		},
 		'event/TransitionListChanged'({dispatch}) {
 			return dispatch('transitions/reload')
@@ -33,6 +33,9 @@ export default {
 	},
 	mutations: {
 		'transitions/current'(state, {'current-transition': name}) {
+			state.current = name
+		},
+		'transitions/newcurrent'(state, {'transition-name': name}) {
 			state.current = name
 		},
 		'transitions/list'(state, {transitions}) {

--- a/src/store/plugins/obs/module/transitions.js
+++ b/src/store/plugins/obs/module/transitions.js
@@ -1,0 +1,59 @@
+export default {
+	state: {
+		current: null,
+		list: [],
+		duration: null
+	},
+	actions: {
+		'connection/closed'({commit}) {
+			commit('transitions/reset')
+		},
+		async 'connection/ready'({dispatch}) {
+			return dispatch('transitions/reload')
+		},
+		async 'transitions/reload'({commit, getters: {client}}) {
+			const {'current-transition': current, transitions} = await client.send({'request-type': 'GetTransitionList'})
+
+			commit('transitions/list', {transitions})
+			commit('transitions/current', {
+				'current-transition': current
+			})
+		},
+		'transitions/current'({getters: {client}}, {name}) {
+			return client.send({'request-type': 'SetCurrentTransition', 'transition-name': name})
+		},
+		'transitions/duration'({getters: {client}}, {ms}) {
+			return client.send({'request-type': 'SetTransitionDuration', 'duration': ms})
+		},
+		'event/SwitchTransition'({dispatch}) {
+			return dispatch('transitions/reload')
+		},
+		'event/TransitionListChanged'({dispatch}) {
+			return dispatch('transitions/reload')
+		},
+		'event/TransitionBegin'({commit}, data) {
+			console.log('TransitionBegin', data) // TODO: figure out proper conditional logging
+		},
+		'event/TransitionDurationChanged'({commit}, data) {
+			//console.log('TransitionDurationChanged', data) // TODO: figure out proper conditional logging
+			commit('transitions/durationChanged',data)
+		}
+	},
+	// getters here?
+	mutations: {
+		'transitions/current'(state, {'current-transition': name}) {
+			state.current = name
+		},
+		'transitions/list'(state, {transitions}) {
+			state.list = transitions
+		},
+		'transitions/reset'(state) {
+			state.current = null
+			state.list = []
+			state.duration = null
+		},
+		'transitions/durationChanged'(state, {'new-duration': newDuration}) {
+			state.duration = newDuration
+		}
+	}
+}

--- a/src/store/plugins/obs/module/transitions.js
+++ b/src/store/plugins/obs/module/transitions.js
@@ -1,18 +1,17 @@
 export default {
 	state: {
 		current: null,
-		list: [],
-		duration: null
+		list: []
 	},
 	actions: {
 		'connection/closed'({commit}) {
 			commit('transitions/reset')
 		},
-		async 'connection/ready'({dispatch}) {
+		'connection/ready'({dispatch}) {
 			return dispatch('transitions/reload')
 		},
 		async 'transitions/reload'({commit, getters: {client}}) {
-			const {'current-transition': current, transitions} = await client.send({'request-type': 'GetTransitionList'})
+			const {'current-transition': current, 'transitions': transitions} = await client.send({'request-type': 'GetTransitionList'})
 
 			commit('transitions/list', {transitions})
 			commit('transitions/current', {
@@ -22,21 +21,15 @@ export default {
 		'transitions/current'({getters: {client}}, {name}) {
 			return client.send({'request-type': 'SetCurrentTransition', 'transition-name': name})
 		},
-		'transitions/duration'({getters: {client}}, duration) {
-			return client.send({'request-type': 'SetTransitionDuration', duration})
-		},
 		'event/SwitchTransition'({dispatch}) {
 			return dispatch('transitions/reload')
 		},
 		'event/TransitionListChanged'({dispatch}) {
 			return dispatch('transitions/reload')
-		},
-		'event/TransitionBegin'({commit}, data) {
-			console.log('TransitionBegin', data) // TODO: figure out proper conditional logging
-		},
-		'event/TransitionDurationChanged'({commit}, data) {
-			commit('transitions/durationChanged', data)
 		}
+		//'event/TransitionBegin'({commit}, data) {
+		//	console.log('TransitionBegin', data) // TODO: figure out proper conditional logging
+		//}
 	},
 	mutations: {
 		'transitions/current'(state, {'current-transition': name}) {
@@ -48,10 +41,6 @@ export default {
 		'transitions/reset'(state) {
 			state.current = null
 			state.list = []
-			state.duration = null
-		},
-		'transitions/durationChanged'(state, {'new-duration': newDuration}) {
-			state.duration = newDuration
 		}
 	}
 }

--- a/src/store/plugins/obs/module/transitions.js
+++ b/src/store/plugins/obs/module/transitions.js
@@ -26,10 +26,10 @@ export default {
 		},
 		'event/TransitionListChanged'({dispatch}) {
 			return dispatch('transitions/reload')
+		},
+		'event/TransitionBegin'({commit}, data) {
+			// Do I do anything or simple discard for now?!
 		}
-		//'event/TransitionBegin'({commit}, data) {
-		//	console.log('TransitionBegin', data) // TODO: figure out proper conditional logging
-		//}
 	},
 	mutations: {
 		'transitions/current'(state, {'current-transition': name}) {

--- a/src/store/plugins/obs/module/transitions.js
+++ b/src/store/plugins/obs/module/transitions.js
@@ -22,7 +22,7 @@ export default {
 			return client.send({'request-type': 'SetCurrentTransition', 'transition-name': name})
 		},
 		'event/SwitchTransition'({commit}, data) {
-			commit('transitions/newcurrent',  data)
+			commit('transitions/newcurrent', data)
 		},
 		'event/TransitionListChanged'({dispatch}) {
 			return dispatch('transitions/reload')

--- a/src/store/plugins/obs/modules.js
+++ b/src/store/plugins/obs/modules.js
@@ -1,7 +1,9 @@
 import scenes from './module/scenes'
 import stream from './module/stream'
+import transitions from './module/transitions'
 
 export default {
 	scenes,
-	stream
+	stream,
+	transitions
 }

--- a/src/store/plugins/obs/modules.js
+++ b/src/store/plugins/obs/modules.js
@@ -1,9 +1,11 @@
 import scenes from './module/scenes'
 import stream from './module/stream'
 import transitions from './module/transitions'
+import durations from './module/durations'
 
 export default {
 	scenes,
 	stream,
-	transitions
+	transitions,
+	durations
 }

--- a/src/stylesheets/app.scss
+++ b/src/stylesheets/app.scss
@@ -32,6 +32,7 @@ html {
 @import "panels/sources";
 @import "panels/stream";
 @import "panels/transitions";
+@import "panels/durations";
 
 @import "pages/connect";
 @import "pages/dashboard";

--- a/src/stylesheets/app.scss
+++ b/src/stylesheets/app.scss
@@ -31,6 +31,7 @@ html {
 @import "panels/scenes";
 @import "panels/sources";
 @import "panels/stream";
+@import "panels/transitions";
 
 @import "pages/connect";
 @import "pages/dashboard";

--- a/src/stylesheets/panels/_durations.scss
+++ b/src/stylesheets/panels/_durations.scss
@@ -1,18 +1,18 @@
-.panel-transitions {
+.panel-durations {
 	display: flex;
 	flex-direction: column;
 
-	& > .transitions-list {
+	& > .current-duration {
 			text-align: center;
 		}
 
-	& > .transitions {
+	& > .durations {
 		display: flex;
 		flex-direction: column;
 		flex: 1 1 auto;
 		overflow-y: auto;
 
-		& > .transition {
+		& > .duration {
 			border: none;
 			flex: 0 0 auto;
 			overflow: hidden;

--- a/src/stylesheets/panels/_sources.scss
+++ b/src/stylesheets/panels/_sources.scss
@@ -20,6 +20,7 @@
 		& > .source {
 			border: none;
 			flex: 0 0 auto;
+			overflow: hidden;
 			text-overflow: ellipsis;
 			white-space: nowrap;
 		}

--- a/src/stylesheets/panels/_transitions.scss
+++ b/src/stylesheets/panels/_transitions.scss
@@ -1,0 +1,30 @@
+.panel-transitions {
+	display: flex;
+	flex-direction: column;
+
+	& > .transitions-list {
+			text-align: center;
+		}
+
+	& > .transitions {
+		display: flex;
+		flex-direction: column;
+		flex: 1 1 auto;
+		overflow-y: auto;
+
+		& > .transition,
+		& > .duration {
+			border: none;
+			flex: 0 0 auto;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+			/* border: 1px solid #0c7cd5; // eventually to be fixed in buttons? */
+		}
+		& > hr {
+			width: 20%;
+			height: 0;
+			margin:2px auto;
+		}
+	}
+}

--- a/src/stylesheets/panels/_transitions.scss
+++ b/src/stylesheets/panels/_transitions.scss
@@ -19,7 +19,6 @@
 			overflow: hidden;
 			text-overflow: ellipsis;
 			white-space: nowrap;
-			/* border: 1px solid #0c7cd5; // eventually to be fixed in buttons? */
 		}
 		& > hr {
 			width: 20%;


### PR DESCRIPTION
Creates two new panels for remote management of transitions and durations (currently a list of static durations -- plan to enhance in a later release, but values now are good).