### PR TITLE
Should fix adding/removing items from a scene

### DIFF
--- a/src/store/plugins/obs/module/scenes.js
+++ b/src/store/plugins/obs/module/scenes.js
@@ -35,6 +35,13 @@ export default {
 		'event/ScenesChanged'({dispatch}) {
 			return dispatch('scenes/reload')
 		},
+		'event/SceneItemAdded'({dispatch}) {
+			return dispatch('scenes/reload')
+		},
+		'event/SceneItemRemoved'({dispatch}) {
+			return dispatch('scenes/reload')
+		},
+		// no event from obs-websocket (in 4.2.0 at least) for something like 'SceneItemChanged' (like rename)
 		'event/SceneItemVisibilityChanged'({commit}, data) {
 			commit('scenes/itemVisibilityChanged', data)
 		}


### PR DESCRIPTION
(perhaps not optimized, doing entire reload **BUT** this will catch items being renamed
 for which there is no 4.2.0 obs-websocket event... YET)