### PR TITLE
Check if port is undefined before using it

### DIFF
--- a/src/obs-remote.js
+++ b/src/obs-remote.js
@@ -30,7 +30,7 @@ export default class OBSRemote extends EventEmitter {
 		return new Promise((resolve, reject) => {
 			this._connecting = {resolve, reject}
 
-			const url = 'ws://' + host + ':' + port
+			const url = 'ws://' + host + (port ? ':' + port : '')
 			this._socket = new WebSocket(url)
 
 			this._socket.addEventListener('open', socketOnOpen.bind(this))


### PR DESCRIPTION
**Change**
If the user has left the port field empty in connections settings, do not use it when creating the OBS connection

**Motivation**
This change allows using proxies that use other than root url path (such as ws://example.com/obs) and do not require special ports. Also perhaps the most simple change to achieve the effect.

Also a step towards solving #29.

**How to test**
1) Try to connect with a port value
2) Try to connect without a port value