### PR TITLE
Only prepend the host with protocol when not present already

### DIFF
--- a/src/obs-remote.js
+++ b/src/obs-remote.js
@@ -30,7 +30,8 @@ export default class OBSRemote extends EventEmitter {
 		return new Promise((resolve, reject) => {
 			this._connecting = {resolve, reject}
 
-			const url = 'ws://' + host + (port ? ':' + port : '')
+			const protocol = (host.startsWith('ws://') || host.startsWith('wss://')) ? '' : 'ws://';
+			const url = protocol + host + (port ? ':' + port : '')
 			this._socket = new WebSocket(url)
 
 			this._socket.addEventListener('open', socketOnOpen.bind(this))


### PR DESCRIPTION
**Change**
If the user defines a protocol (ws:// or wss://) in the connection url input field, use that instead of the default "ws://".

**Motivation**
This change allows using proxies with ssl encryption. A step towards solving #29.

**How to test**
1) Try to connect with an url without a protocol
2) Try to connect with an url starting with "ws://"
2) Try to connect with an url starting with "wss://"
Each time check web console to see the actual url the connection attempt is made to.

**Breaking changes**
No. The default behaviour remains the same and no users experience a change in expected behaviour.