### PR TITLE
Update index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
 		<meta charset="utf-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<meta name="viewport" content="width=device-width,initial-scale=1.0">
+		<meta name="apple-mobile-web-app-capable" content="yes">
 		<title>OBS Tablet Remote</title>
 		<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 	</head>


### PR DESCRIPTION
- Allows the app to be run in true fullscreen on iOS (outside of a web browser), when the user chooses "Add to Home Screen" from the website options in Safari.
- Currently you can add the webpage to the Home Screen, but without this meta tag, it just opens in a tab in Safari.
- While the app's current fullscreen mode already works in Safari, it only works in Safari, and automatically cancels if you drag the screen down too far. Using this method to open it fullscreen outside a browser prevents that annoyance.

No idea if there's a similar thing for Android, I have no such devices.