### PR TITLE
Not to select text on buttons

### DIFF
--- a/src/assets/styles/components/buttons.css
+++ b/src/assets/styles/components/buttons.css
@@ -1,6 +1,8 @@
 .button {
 	@apply p-3 leading-none;
 	transition: background-color 0.25s;
+	user-select: none;
+	-webkit-touch-callout: behavior;
 	&:focus {
 		@apply .shadow-outline;
 	}


### PR DESCRIPTION
When I tap a button strongly or long time, the text is selected instead of dispatching the button as a picture below. When this happens, even another tap on the button does not work.
![83267a](https://user-images.githubusercontent.com/780600/82726090-d536b980-9d1c-11ea-828e-5b1b8dcb0066.jpg)
I'd like to suggest to disable selecting text on buttons.
I've tested with Safari on iPhone.