### PR TITLE
One click on scene to see sources, second to make it current

### DIFF
--- a/src/components/panels/scenes.vue
+++ b/src/components/panels/scenes.vue
@@ -35,45 +35,45 @@
 				</div>
 			</div>
 
-			<h3 class="text-xl mb-2">
-				Transition Scene
-			</h3>
-			<div class="field">
-				<label
-					:for="`settings-${id}-transition-scene`"
-					class="label"
-				>Transition Scene</label>
-				<select
-					:id="`settings-${id}-transition-scene`"
-					v-model="transitionScene"
-					class="select"
-				>
-					<option :value="undefined">
-						None
-					</option>
-					<option
-						v-for="scene in scenes"
-						:key="scene.name"
-						:value="scene.name"
-					>
-						{{ scene.name }}
-					</option>
-				</select>
-			</div>
-			<div class="field">
-				<label
-					:for="`settings-${id}-transition-time`"
-					class="label"
-				>Transition Time</label>
-				<input
-					:id="`settings-${id}-transition-time`"
-					v-model.number="transitionSeconds"
-					class="input"
-					type="number"
-					min="0"
-					step="0.1"
-				>
-			</div>
+			<!--			<h3 class="text-xl mb-2">-->
+			<!--				Transition Scene-->
+			<!--			</h3>-->
+			<!--			<div class="field">-->
+			<!--				<label-->
+			<!--					:for="`settings-${id}-transition-scene`"-->
+			<!--					class="label"-->
+			<!--				>Transition Scene</label>-->
+			<!--				<select-->
+			<!--					:id="`settings-${id}-transition-scene`"-->
+			<!--					v-model="transitionScene"-->
+			<!--					class="select"-->
+			<!--				>-->
+			<!--					<option :value="undefined">-->
+			<!--						None-->
+			<!--					</option>-->
+			<!--					<option-->
+			<!--						v-for="scene in scenes"-->
+			<!--						:key="scene.name"-->
+			<!--						:value="scene.name"-->
+			<!--					>-->
+			<!--						{{ scene.name }}-->
+			<!--					</option>-->
+			<!--				</select>-->
+			<!--			</div>-->
+			<!--			<div class="field">-->
+			<!--				<label-->
+			<!--					:for="`settings-${id}-transition-time`"-->
+			<!--					class="label"-->
+			<!--				>Transition Time</label>-->
+			<!--				<input-->
+			<!--					:id="`settings-${id}-transition-time`"-->
+			<!--					v-model.number="transitionSeconds"-->
+			<!--					class="input"-->
+			<!--					type="number"-->
+			<!--					min="0"-->
+			<!--					step="0.1"-->
+			<!--				>-->
+			<!--			</div>-->
 		</template>
 	</panel-wrapper>
 </template>
@@ -118,20 +118,27 @@ export default {
 		},
 		...mapState('obs', {
 			currentScene: state => state.scenes.current,
+			previewScene: state => state.scenes.preview,
 			scenes: state => state.scenes.list
 		})
 	},
 	methods: {
 		async switchScenes(name) {
-			if (this.transitionScene && this.transitionSeconds > 0) {
-				this.setScene({name: this.transitionScene})
-				await timeoutPromise(this.transitionSeconds * 1000)
-			}
+			// eslint-disable-next-line no-negated-condition
+			if (name !== this.previewScene) {
+				this.setPreview({name})
+			} else {
+				if (this.transitionScene && this.transitionSeconds > 0) {
+					this.setScene({name: this.transitionScene})
+					await timeoutPromise(this.transitionSeconds * 1000)
+				}
 
-			await this.setScene({name})
+				await this.setScene({name})
+			}
 		},
 		...mapActions('obs', {
-			setScene: 'scenes/current'
+			setScene: 'scenes/current',
+			setPreview: 'scenes/preview'
 		})
 	}
 }

--- a/src/components/panels/sources.vue
+++ b/src/components/panels/sources.vue
@@ -5,18 +5,18 @@
 		</template>
 
 		<h3 class="p-2 text-center font-bold">
-			{{ currentScene ? currentScene.name : 'Unknown Scene' }}
+			{{ viewScene ? viewScene.name : 'Unknown Scene' }}
 		</h3>
 		<div
-			v-if="currentScene"
+			v-if="viewScene"
 			class="flex-grow button-grid has-per-row-1 overflow-y-auto"
 		>
 			<button
-				v-for="source in currentScene.sources"
+				v-for="source in viewScene.sources"
 				:key="source.name"
 				class="button"
 				:class="[source.render ? 'is-active' : 'is-inactive']"
-				@click="setRender({scene: currentScene.name, source: source.name, render: !source.render})"
+				@click="setRender({scene: viewScene.name, source: source.name, render: !source.render})"
 			>
 				{{ source.name }}
 			</button>
@@ -35,7 +35,7 @@ import panelMixin from '@/mixins/panel'
 export default {
 	mixins: [panelMixin],
 	computed: {
-		...mapGetters('obs', ['currentScene'])
+		...mapGetters('obs', ['viewScene'])
 	},
 	methods: {
 		...mapActions({

--- a/src/store/plugins/obs/module/scenes.js
+++ b/src/store/plugins/obs/module/scenes.js
@@ -1,6 +1,7 @@
 export default {
 	state: {
 		current: null,
+		preview: null,
 		list: []
 	},
 	actions: {
@@ -18,8 +19,11 @@ export default {
 				'scene-name': current
 			})
 		},
-		'scenes/current'({getters: {client}}, {name}) {
+		async 'scenes/current'({getters: {client}}, {name}) {
 			return client.send({'request-type': 'SetCurrentScene', 'scene-name': name})
+		},
+		'scenes/preview'({commit}, {name}) {
+			commit('scenes/preview', name)
 		},
 		async 'sources/render'({getters: {client}}, {scene, source, render}) {
 			return client.send({
@@ -49,11 +53,21 @@ export default {
 	getters: {
 		currentScene(state) {
 			return state.list.find(scene => scene.name === state.current)
+		},
+		previewScene(state) {
+			return state.list.find(scene => scene.name === state.preview)
+		},
+		viewScene(state) {
+			const name = state.preview || state.current
+			return state.list.find(scene => scene.name === name)
 		}
 	},
 	mutations: {
 		'scenes/current'(state, {'scene-name': name}) {
 			state.current = name
+		},
+		'scenes/preview'(state, preview) {
+			state.preview = preview
 		},
 		'scenes/list'(state, {scenes}) {
 			state.list = scenes

--- a/src/store/plugins/obs/module/transitions.js
+++ b/src/store/plugins/obs/module/transitions.js
@@ -29,6 +29,12 @@ export default {
 		},
 		'event/TransitionBegin'() {
 			// Do I do anything or simple discard for now?!
+		},
+		'event/TransitionEnd'() {
+			// Let it be
+		},
+		'event/TransitionVideoEnd'() {
+			// Mb will need later
 		}
 	},
 	mutations: {


### PR DESCRIPTION
On first click the scene become preview and all sources are shown by preview scene. On the second click check if clicked scene name same as preview and then make it current. It's possible to make a setting for sources panel to choice show sources of the preview or the current scene. 
Scene transition works incorrect: if transition time is small enough it's possible chosen scene won't show up. I commented it out. 
Added empty actions for TransitionEnd and TransitionVideoEnd to stop spamming error that they don't exist. 
The throttle cut eyes - change it to 15 ms from 33 ms so it doesn't overload system and looks good. 
