### PR TITLE
Simplified filter to remove hidden scenes

### DIFF
--- a/src/components/panels/scenes.vue
+++ b/src/components/panels/scenes.vue
@@ -5,7 +5,7 @@
 		</template>
 
 		<button
-			v-for="scene in scenes"
+			v-for="scene in filteredScenes"
 			:key="scene.name"
 			class="button"
 			:class="[scene.name === currentScene ? 'is-active' : 'is-inactive']"
@@ -118,7 +118,12 @@ export default {
 		},
 		...mapState('obs', {
 			currentScene: state => state.scenes.current,
-			scenes: state => state.scenes.list
+			scenes: state => state.scenes.list,
+			filteredScenes(state) {
+				return state.scenes.list.filter(scene => {
+					return ~/.*(?:\[hidden]|\^\^}~~)$/i.test(scene.name)
+				})
+			}
 		})
 	},
 	methods: {


### PR DESCRIPTION
## Filter Scenes by Name in the Vue Computed Data Function

This PR proposes a fixed format for identifying scenes to hide from the Scenes panel. For more complex productions with multiple nested scenes, the display in this remote becomes cluttered, button names become difficult to differentiate, and each touch target becomes dangerously small.

### Hiding a Scene

To hide a scene, simply add any of these three strings to the end of the scene name:
- `[Hidden]`
- `^^`
- `~~`

### Change Description

This PR simply adds a computed property to the panel that uses the `Array.filter()` function to remove any scenes whose names match a Regular Expression seeking one of those three signifiers on the end.

Then, rather than using the unfiltered scene array to populate the list, the `v-for` clause now pulls scenes from the filtered list.

### Comparison to Other PRs

There is one other PR to accomplish something similar, allowing for the user to specify a prefix; however, that method runs into issues when removing or changing the prefix.

This approach is less flexible in that it does not allow for arbitrary tagging to remove scenes from the list, but it completely avoids the problem of causing a blank list when changing the tag.

This method also avoids the combination of `v-for` and `v-if`.

The `^^` or `~~` strings are exceedingly unlikely to be used in general practice, and should not conflict with desired scenes.

`[Hidden]` is more obvious to English-speaking users, but not conducive to translation in this RegEx.