### PR TITLE
Fixed Bad RegEx

### DIFF
--- a/src/components/panels/scenes.vue
+++ b/src/components/panels/scenes.vue
@@ -121,7 +121,11 @@ export default {
 			scenes: state => state.scenes.list,
 			filteredScenes(state) {
 				return state.scenes.list.filter(scene => {
-					return ~/.*(?:\[hidden]|\^\^}~~)$/i.test(scene.name)
+					// Incorrect RegEx:
+					//	~/.*(?:\[hidden]|\^\^}~~)$/i
+					// Correct RegEx:
+					//	!/.*(?:\[hidden]|\^\^|~~)$/i
+					return !/.*(?:\[hidden]|\^\^|~~)$/i.test(scene.name)
 				})
 			}
 		})


### PR DESCRIPTION
I don't know if this was my error, or if something got corrupted along
the way, but the filter expression in the repo is not what I have in my
source. This commit (should) fix it. I've included the bad and good
expressions in the comments for reference.

Bad RegEx:
    `~/.*(?:\[hidden]|\^\^}~~)$/i`
Good RegEx:
    `!/.*(?:\[hidden]|\^\^|~~)$/i`

This prevented the filter from working, but the corrected RegEx
should take care of the problem.