### PR TITLE
Correct a faulty Regular Expression

### DIFF
--- a/src/components/panels/scenes.vue
+++ b/src/components/panels/scenes.vue
@@ -121,7 +121,11 @@ export default {
 			scenes: state => state.scenes.list,
 			filteredScenes(state) {
 				return state.scenes.list.filter(scene => {
-					return ~/.*(?:\[hidden]|\^\^}~~)$/i.test(scene.name)
+					// Bad RegEx:
+					//	"~/.*(?:\[hidden]|\^\^}~~)$/i"
+					// Fixed RegEx:
+					//	"!/.*(?:\[hidden]|\^\^|~~)$/i"
+					return !/.*(?:\[hidden]|\^\^|~~)$/i.test(scene.name)
 				})
 			}
 		})

--- a/src/components/panels/scenes.vue
+++ b/src/components/panels/scenes.vue
@@ -5,7 +5,7 @@
 		</template>
 
 		<button
-			v-for="scene in scenes"
+			v-for="scene in filteredScenes"
 			:key="scene.name"
 			class="button"
 			:class="[scene.name === currentScene ? 'is-active' : 'is-inactive']"
@@ -118,7 +118,12 @@ export default {
 		},
 		...mapState('obs', {
 			currentScene: state => state.scenes.current,
-			scenes: state => state.scenes.list
+			scenes: state => state.scenes.list,
+			filteredScenes(state) {
+				return state.scenes.list.filter(scene => {
+					return ~/.*(?:\[hidden]|\^\^}~~)$/i.test(scene.name)
+				})
+			}
 		})
 	},
 	methods: {


### PR DESCRIPTION
### Correct the Scene Filter for All Users
Two characters in my last commit somehow ended up incorrect. This commit updates the Regular Expression (and puts the faulty and corrected expressions in comments) so that the filter works correctly for everyone.

#### Bad Expression
`~/.*(?:\[hidden]|\^\^}~~)$/i`

#### Correct Expression
`!/.*(?:\[hidden]|\^\^|~~)$/i`
Note the `!` point instead of the `~` in the first position, negating the comparison. Also, note the `}` that should be a `|` toward the end of the expression that should allow the expression to match `[hidden]`, `^^`, or `~~`, but instead would have matched `[hidden]` or `^^}~~` incorrectly.